### PR TITLE
use setuptools instead of distutils, if it's available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ if sys.version_info > (3,):
     setup_kwds["test_suite"] = "djsupervisor.tests"
     setup_kwds["use_2to3"] = True
 else:
-    from distutils.core import setup
+    try:
+        from setuptools import setup
+    except ImportError:
+        from distutils.core import setup
 
 
 try:


### PR DESCRIPTION
Hey,

Great project -- thanks a lot for releasing it.  I'm already finding it very useful.

This change uses setuptools in py2 if it's available, and only falls back on distutils if it's not.  This is helpful to me when hacking on django-supervisor itself -- it lets me `python setup.py develop` the project so that I don't have to reinstall it every time I make a code change.
