### PR TITLE
Implement graceful reloading using SIGHUP

### DIFF
--- a/djsupervisor/events.py
+++ b/djsupervisor/events.py
@@ -3,23 +3,19 @@ import time
 
 from watchdog.events import PatternMatchingEventHandler
 
-
-class CallbackModifiedHandler(PatternMatchingEventHandler):
+class ThrottledModifiedHandler(PatternMatchingEventHandler):
     """
     A pattern matching event handler that calls the provided
     callback when a file is modified.
     """
-    def __init__(self, callback, *args, **kwargs):
-        self.callback = callback
-        self.repeat_delay = kwargs.pop("repeat_delay", 0)
-        self.graceful = kwargs.pop("graceful", False)
-        self.last_fired_time = 0
-        super(CallbackModifiedHandler, self).__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        self.event_count = 0
+        super(ThrottledModifiedHandler, self).__init__(*args, **kwargs)
 
     def on_modified(self, event):
-        super(CallbackModifiedHandler, self).on_modified(event)
-        now = time.time()
-        if self.last_fired_time + self.repeat_delay < now:
-            if not event.is_directory:
-                self.last_fired_time = now
-                self.callback(self.graceful)
+        super(ThrottledModifiedHandler, self).on_modified(event)
+        if not event.is_directory:
+            self.event_count += 1
+
+    def reset_counter(self):
+        self.event_count = 0

--- a/djsupervisor/events.py
+++ b/djsupervisor/events.py
@@ -12,6 +12,7 @@ class CallbackModifiedHandler(PatternMatchingEventHandler):
     def __init__(self, callback, *args, **kwargs):
         self.callback = callback
         self.repeat_delay = kwargs.pop("repeat_delay", 0)
+        self.graceful = kwargs.pop("graceful", False)
         self.last_fired_time = 0
         super(CallbackModifiedHandler, self).__init__(*args, **kwargs)
 
@@ -21,4 +22,4 @@ class CallbackModifiedHandler(PatternMatchingEventHandler):
         if self.last_fired_time + self.repeat_delay < now:
             if not event.is_directory:
                 self.last_fired_time = now
-                self.callback()
+                self.callback(self.graceful)

--- a/djsupervisor/events.py
+++ b/djsupervisor/events.py
@@ -9,13 +9,16 @@ class ThrottledModifiedHandler(PatternMatchingEventHandler):
     callback when a file is modified.
     """
     def __init__(self, *args, **kwargs):
+        self.event_files = []
         self.event_count = 0
         super(ThrottledModifiedHandler, self).__init__(*args, **kwargs)
 
     def on_modified(self, event):
         super(ThrottledModifiedHandler, self).on_modified(event)
         if not event.is_directory:
+            self.event_files.append(event.src_path)
             self.event_count += 1
 
     def reset_counter(self):
         self.event_count = 0
+        self.event_files = []

--- a/djsupervisor/management/commands/supervisor.py
+++ b/djsupervisor/management/commands/supervisor.py
@@ -46,7 +46,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
 from djsupervisor.config import get_merged_config
-from djsupervisor.events import CallbackModifiedHandler
 from djsupervisor.events import ThrottledModifiedHandler
 
 AUTORELOAD_PATTERNS = getattr(settings, "SUPERVISOR_AUTORELOAD_PATTERNS",

--- a/djsupervisor/management/commands/supervisor.py
+++ b/djsupervisor/management/commands/supervisor.py
@@ -238,10 +238,11 @@ class Command(BaseCommand):
 
         # Call the autoreloader callback whenever a .py file changes.
         # To prevent thrashing, limit callbacks to one per second.
-        handler = ThrottledModifiedHandler(repeat_delay=1,
-                                          patterns=AUTORELOAD_PATTERNS,
-                                          ignore_patterns=AUTORELOAD_IGNORE,
-                                          ignore_directories=True)
+        handler = ThrottledModifiedHandler(
+          patterns=AUTORELOAD_PATTERNS,
+          ignore_patterns=AUTORELOAD_IGNORE,
+          ignore_directories=True
+        )
 
         # Try to add watches using the platform-specific observer.
         # If this fails, print a warning and fall back to the PollingObserver.

--- a/djsupervisor/management/commands/supervisor.py
+++ b/djsupervisor/management/commands/supervisor.py
@@ -299,7 +299,7 @@ class Command(BaseCommand):
         for section in cfg.sections():
             if section.startswith("program:"):
                 try:
-                    patterns = cfg.get(section, "autoreload_patterns") if cfg.has_option(section, "autoreload_patterns") else AUTORELOAD_PATTERNS
+                    patterns = cfg.get(section, "autoreload_patterns").split(",") if cfg.has_option(section, "autoreload_patterns") else AUTORELOAD_PATTERNS
                     if cfg.getboolean(section,"autoreload"):
                         if cfg.getboolean(section, "autoreload_graceful"):
                             graceful_reload_progs[section.split(":",1)[1]] = patterns

--- a/djsupervisor/management/commands/supervisor.py
+++ b/djsupervisor/management/commands/supervisor.py
@@ -304,7 +304,7 @@ class Command(BaseCommand):
                         if cfg.getboolean(section, "autoreload_graceful"):
                             graceful_reload_progs[section.split(":",1)[1]] = patterns
                         else:
-                            reload_progs.append[section.split(":",1)[1]] = patterns
+                            reload_progs[section.split(":",1)[1]] = patterns
                 except NoOptionError:
                     pass
         return (reload_progs, graceful_reload_progs)

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
   install_requires=[
     "supervisor",
     "watchdog",
+    "pathtools",
   ],
   **setup_kwds
 )


### PR DESCRIPTION
This is actually a missing feature in supervisord (https://github.com/Supervisor/supervisor/issues/53).

In addition to django-supervisor's autoreload setting, an autoreload_graceful setting is introduced, which, when set to true, sends a SIGHUP to the PIDs of the process. Successfully tested with gunicorn.
