### PR TITLE
Remove references to deprecated django.utils.importlib

### DIFF
--- a/djsupervisor/config.py
+++ b/djsupervisor/config.py
@@ -23,7 +23,7 @@ from ConfigParser import RawConfigParser, NoSectionError, NoOptionError
 
 from django import template
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 
 from djsupervisor.templatetags import djsupervisor_tags
 


### PR DESCRIPTION
As of Django 1.7 the standard module importlib should be used.